### PR TITLE
Add `TryPinInitWrapper` trait.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Wrapper<T>` trait added for creating wrapper structs with a structurally pinned value.
+
 ### Changed
 
 - `InPlaceInit` now only exists when the `alloc` or `std` features are enabled

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ pin-init-internal = { path = "./internal", version = "=0.0.5" }
 default = ["std", "alloc"]
 std = []
 alloc = []
+unsafe-pinned = []
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,11 @@ prettyplease = { version = "0.2", features = ["verbatim"] }
 
 [lints.rust]
 non_ascii_idents = "deny"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(NO_UI_TESTS)', 'cfg(NO_ALLOC_FAIL_TESTS)', 'cfg(kernel)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(NO_UI_TESTS)',
+    'cfg(NO_ALLOC_FAIL_TESTS)',
+    'cfg(kernel)',
+] }
 unsafe_op_in_unsafe_fn = "deny"
 unused_attributes = "deny"
 warnings = "deny"

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ the `kernel` crate. The [`sync`] module is a good starting point.
 
 [`sync`]: https://rust.docs.kernel.org/kernel/sync/index.html
 [pinning]: https://doc.rust-lang.org/std/pin/index.html
-[structurally pinned fields]: https://doc.rust-lang.org/std/pin/index.html#pinning-is-structural-for-field
+[structurally pinned fields]: https://doc.rust-lang.org/std/pin/index.html#projections-and-structural-pinning
 [stack]: https://docs.rs/pin-init/latest/pin_init/macro.stack_pin_init.html
 [`impl PinInit<Foo>`]: https://docs.rs/pin-init/latest/pin_init/trait.PinInit.html
 [`impl PinInit<T, E>`]: https://docs.rs/pin-init/latest/pin_init/trait.PinInit.html

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ However, using the crate on stable compilers is possible by disabling `alloc`. I
 will require the `std` feature, because stable compilers have neither `Box` nor `Arc` in no-std
 mode.
 
+### Nightly needed for `unsafe-pinned` feature
+
+This feature enables the `Wrapper` implementation on the unstable `core::pin::UnsafePinned` type.
+This requires the [`unsafe_pinned` unstable feature](https://github.com/rust-lang/rust/issues/125735)
+and therefore a nightly compiler. Note that this feature is not enabled by default.
+
 ## Overview
 
 To initialize a `struct` with an in-place constructor you will need two things:

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,7 @@ use rustc_version::{version, Version};
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(RUSTC_LINT_REASONS_IS_STABLE)");
     println!("cargo::rustc-check-cfg=cfg(RUSTC_NEW_UNINIT_IS_STABLE)");
+    println!("cargo::rustc-check-cfg=cfg(CONFIG_RUSTC_HAS_UNSAFE_PINNED)");
     if version().unwrap() >= Version::parse("1.81.0").unwrap()
         || version().unwrap() >= Version::parse("1.81.0-nightly").unwrap()
     {
@@ -10,5 +11,8 @@ fn main() {
     }
     if version().unwrap() >= Version::parse("1.82.0").unwrap() {
         println!("cargo:rustc-cfg=RUSTC_NEW_UNINIT_IS_STABLE");
+    }
+    if version().unwrap() >= Version::parse("1.88.0-nightly").unwrap() {
+        println!("cargo:rustc-cfg=CONFIG_RUSTC_HAS_UNSAFE_PINNED");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@
 //! [`sync`]: https://rust.docs.kernel.org/kernel/sync/index.html
 //! [pinning]: https://doc.rust-lang.org/std/pin/index.html
 //! [structurally pinned fields]:
-//!     https://doc.rust-lang.org/std/pin/index.html#pinning-is-structural-for-field
+//!     https://doc.rust-lang.org/std/pin/index.html#projections-and-structural-pinning
 //! [stack]: crate::stack_pin_init
 #![cfg_attr(
     kernel,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,12 @@
 //! will require the `std` feature, because stable compilers have neither `Box` nor `Arc` in no-std
 //! mode.
 //!
+//! ## Nightly needed for `unsafe-pinned` feature
+//!
+//! This feature enables the `Wrapper` implementation on the unstable `core::pin::UnsafePinned` type.
+//! This requires the [`unsafe_pinned` unstable feature](https://github.com/rust-lang/rust/issues/125735)
+//! and therefore a nightly compiler. Note that this feature is not enabled by default.
+//!
 //! # Overview
 //!
 //! To initialize a `struct` with an in-place constructor you will need two things:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,6 +269,10 @@
 #![forbid(missing_docs, unsafe_op_in_unsafe_fn)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
+#![cfg_attr(
+    all(feature = "unsafe-pinned", CONFIG_RUSTC_HAS_UNSAFE_PINNED),
+    feature(unsafe_pinned)
+)]
 
 use core::{
     cell::UnsafeCell,
@@ -1555,5 +1559,13 @@ impl<T> Wrapper<T> for MaybeUninit<T> {
     fn pin_init<E>(value_init: impl PinInit<T, E>) -> impl PinInit<Self, E> {
         // SAFETY: `MaybeUninit<T>` has a compatible layout to `T`.
         unsafe { cast_pin_init(value_init) }
+    }
+}
+
+#[cfg(all(feature = "unsafe-pinned", CONFIG_RUSTC_HAS_UNSAFE_PINNED))]
+impl<T> Wrapper<T> for core::pin::UnsafePinned<T> {
+    fn pin_init<E>(init: impl PinInit<T, E>) -> impl PinInit<Self, E> {
+        // SAFETY: `UnsafePinned<T>` has a compatible layout to `T`.
+        unsafe { cast_pin_init(init) }
     }
 }


### PR DESCRIPTION
Implement it for `UnsafeCell` and `UnsafePinned` (unsafe-pinned feature is enabled.

There are probably a large amount of other types where a implementation might be useful,
but for now only implement these types. Others can be implemented in follow-ups.

I'm not sure how to handle enabling the `UnsafePinned`, for now I've just implemented it as a cargo feature. 