### PR TITLE
fix `Example` header

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -953,7 +953,7 @@ macro_rules! try_init {
 /// Asserts that a field on a struct using `#[pin_data]` is marked with `#[pin]` ie. that it is
 /// structurally pinned.
 ///
-/// # Example
+/// # Examples
 ///
 /// This will succeed:
 /// ```


### PR DESCRIPTION
Upstreaming of https://lore.kernel.org/all/ddd5ce0ac20c99a72a4f1e4322d3de3911056922.1749545815.git.viresh.kumar@linaro.org

cc @vireshk (no action required, just wanted to let you know)