### PR TITLE
ci: avoid running the signed-off-by check in the schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,7 @@ jobs:
         env:
           RUSTFLAGS: "-Dwarnings"
   signed-off-by:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The schedule only gives access to the latest commit via `--depth=1` and that always is a merge commit. It isn't ignored by the `--no-merges` option, because there only is one commit. Thus disable the check if it is running as a schedule.