### PR TITLE
examples: fix `useless_borrows_in_formatting` clippy warning

### DIFF
--- a/examples/mutex.rs
+++ b/examples/mutex.rs
@@ -218,7 +218,7 @@ fn main() {
         for h in handles {
             h.join().expect("thread panicked");
         }
-        println!("{:?}", &*mtx.lock());
+        println!("{:?}", *mtx.lock());
         assert_eq!(*mtx.lock(), workload * thread_count * 2);
     }
 }

--- a/examples/pthread_mutex.rs
+++ b/examples/pthread_mutex.rs
@@ -177,7 +177,7 @@ fn main() {
         for h in handles {
             h.join().expect("thread panicked");
         }
-        println!("{:?}", &*mtx.lock());
+        println!("{:?}", *mtx.lock());
         assert_eq!(*mtx.lock(), workload * thread_count * 2);
     }
 }

--- a/examples/static_init.rs
+++ b/examples/static_init.rs
@@ -117,7 +117,7 @@ fn main() {
         for h in handles {
             h.join().expect("thread panicked");
         }
-        println!("{:?}, {:?}", &*mtx.lock(), &*COUNT.lock());
+        println!("{:?}, {:?}", *mtx.lock(), *COUNT.lock());
         assert_eq!(*mtx.lock(), workload * thread_count * 2);
     }
 }


### PR DESCRIPTION
Clippy 1.97 introduces new `useless_borrows_in_formatting` warning which fires on the pthread example as we have `&*expr` where the format macro takes reference already. Remove the extra borrow.