### PR TITLE
fix build with latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,12 +490,14 @@ macro_rules! stack_pin_init {
     (let $var:ident $(: $t:ty)? = $val:expr) => {
         let val = $val;
         let mut $var = ::core::pin::pin!($crate::__internal::StackInit$(::<$t>)?::uninit());
-        let mut $var = match $crate::__internal::StackInit::init($var, val) {
+        // The `Infallible` error type is what requires the initializer to be infallible. It has
+        // to be annotated here rather than in the `Err` arm below, because binding a value of an
+        // uninhabited type makes everything following it unreachable.
+        let res: ::core::result::Result<_, ::core::convert::Infallible> =
+            $crate::__internal::StackInit::init($var, val);
+        let mut $var = match res {
             Ok(res) => res,
-            Err(x) => {
-                let x: ::core::convert::Infallible = x;
-                match x {}
-            }
+            Err(x) => match x {},
         };
     };
 }

--- a/tests/ui/compile-fail/init/no_error_coercion.stderr
+++ b/tests/ui/compile-fail/init/no_error_coercion.stderr
@@ -7,8 +7,8 @@ error[E0277]: `?` couldn't convert the error to `std::alloc::AllocError`
 19 | |         }? AllocError)
    | |                      ^
    | |                      |
-   | |______________________the trait `From<Infallible>` is not implemented for `std::alloc::AllocError`
-   |                        this can't be annotated with `?` because it has type `Result<_, Infallible>`
+   | |______________________the trait `From<!>` is not implemented for `std::alloc::AllocError`
+   |                        this can't be annotated with `?` because it has type `Result<_, !>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = note: this error originates in the macro `init` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/compile-fail/pin_data/missing_pin.stderr
+++ b/tests/ui/compile-fail/pin_data/missing_pin.stderr
@@ -8,7 +8,7 @@ error[E0277]: the trait bound `impl PinInit<usize>: Init<usize, _>` is not satis
    | |__________- required by a bound introduced by this call
    |
 help: the trait `Init<usize, _>` is not implemented for `impl PinInit<usize>`
-      but trait `Init<impl PinInit<usize>, Infallible>` is implemented for it
+      but trait `Init<impl PinInit<usize>, !>` is implemented for it
   --> src/lib.rs
    |
    | unsafe impl<T> Init<T> for T {}


### PR DESCRIPTION
Binding a value of an uninhabited type now makes everything following it unreachable. In `stack_pin_init!` the `Infallible` annotation is such a binding, so the `match x {}` after it is reported as unreachable and `-Dwarnings` turns that into an error.

Annotate the `Result` instead of the error value, which requires the initializer to be infallible just the same but has nothing following it.

`Infallible` is also printed as `!` in diagnostics now, so bless the two tests that show it.